### PR TITLE
fix: speed improvements and returning state for HASS integration

### DIFF
--- a/src/exoyone/cli/get.py
+++ b/src/exoyone/cli/get.py
@@ -246,7 +246,7 @@ def everything(
             if field.lower() == "shutdown timer":
                 value_text = "Disabled"
                 if isinstance(value, int) and value > 0:
-                    value_text = f"{int(value/60)} minutes"
+                    value_text = f"{int(value / 60)} minutes"
 
             elif field.lower() == "mode cycle speed":
                 value_text = "Disabled"


### PR DESCRIPTION
### Description of change

Speed and test improvements and return state for the Home Assistant integration.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `main` branch
- [X] This pull request follows the [contributing guidelines](https://github.com/Djelibeybi/pyexoyone/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
