### PR TITLE
fix: suppress shutdown timer logs

### DIFF
--- a/src/exoyone/exoyone.py
+++ b/src/exoyone/exoyone.py
@@ -224,15 +224,17 @@ class ExoyOne:
 
     async def set_shutdown_timer(self, minutes: int) -> None:
         """Set a shutdown timer of at least 5 and at most 480 minutes."""
+        minutes = int(minutes)
+
         if minutes == 0:
-            _LOGGER.info("Disabling shutdown timer.")
+            _LOGGER.debug("Disabling shutdown timer.")
 
         elif 1 < minutes < 5:
-            _LOGGER.info("Shutdown timer increased to 5 minutes.")
+            _LOGGER.debug("Shutdown timer set to minimum duration of 5 minutes.")
             minutes = 5
 
         if minutes > 480:
-            _LOGGER.info("Shutdown timer reduced to 8 hours.")
+            _LOGGER.debug("Shutdown timer set to maximum duration of 8 hours.")
             minutes = 480
 
         hours: int = 0


### PR DESCRIPTION
### Description of change

Change the logging of the shutdown timer to debug to suppress it from the Home Assistant logs. Also ensure that the value is an integer.

### Pull-Request Checklist


- [X] Code is up-to-date with the `main` branch
- [X] This pull request follows the [contributing guidelines](https://github.com/Djelibeybi/pyexoyone/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
