### PR TITLE
chore(ci): manually configure poetry upgrade workflow to use Python 3.12

### DIFF
--- a/.github/workflows/poetry-upgrade.yml
+++ b/.github/workflows/poetry-upgrade.yml
@@ -3,10 +3,23 @@ name: Upgrader
 on:
   workflow_dispatch:
   schedule:
-    - cron: "27 11 25 * *"
+    - cron: "45 11 25 * *"
 
 jobs:
   upgrade:
-    uses: browniebroke/github-actions/.github/workflows/poetry-upgrade.yml@v1
-    secrets:
-      gh_pat: ${{ secrets.GH_PAT }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "poetry"
+      - run: rm poetry.lock
+      - run: poetry lock -n
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+          branch: update/poetry-upgrade
+          title: "chore(deps): upgrade dependencies"
+          commit-message: "chore(deps): upgrade dependencies"


### PR DESCRIPTION
### Description of change

Reimplement upgrader workflow locally to use Python 3.12.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/Djelibeybi/pyexoyone/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
