### PR TITLE
fix(release): skip unknown commits in changelog template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
 
   release:
     needs:

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -4,7 +4,7 @@
 
 ## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
 
-{%- for category, commits in release["elements"].items() %}
+{%- for category, commits in release["elements"].items() if category != "unknown" %}
 {# Category title: Breaking, Fix, Documentation #}
 ### {{ category | capitalize }}
 {# List actual changes in the category #}


### PR DESCRIPTION
Filter out the "unknown" category in the changelog template to prevent ParseError objects from being accessed for attributes they don't have. This fixes the CI release failure caused by non-conventional commits (e.g., Dependabot's "Bump X from Y to Z" format).
